### PR TITLE
Release/0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .RData
 .Ruserdata
 *.db
+*.json
 
 __pycache__

--- a/app.R
+++ b/app.R
@@ -1,4 +1,7 @@
 library(DBI)
+library(odbc)
+library(knitr)
+library(kableExtra)
 library(RSQLite)
 library(shiny)
 library(tidyverse)
@@ -6,300 +9,340 @@ library(lubridate)
 library(shinydashboard)
 library(shinycssloaders)
 library(ggpubr)
-source("reu.R")
+#source("reu.R")
 
-DB_FN <- "/mnt/shiny/quant_us/quant.db"
+MEASURANDS <- c("NO2", "O3", "PM2.5")
+STUDY_START <- as_date("2019-12-10")
+STUDY_END <- as_date("2022-10-31")
 
-all_devices <- c(
-    "AQM388",
-    "AQM389",
-    "AQM390",
-    "AQM391",
-    "AQY872",
-    "AQY873A",
-    "AQY874",
-    "AQY875A2",
-    "Ari063",
-    "Ari078",
-    "Ari086",
-    "Ari093",
-    "Ari096",
-    "PA1",
-    "PA2",
-    "PA3",
-    "PA4",
-    "PA5",
-    "PA6",
-    "PA7",
-    "PA8",
-    "PA9",
-    "PA10",
-    "Zep188",
-    "Zep309",
-    "Zep311",
-    "Zep344",
-    "Zep716"
-)
-
+#sidebar <- dashboardSidebar(
+#    sidebarMenu(
+#        #menuItem("Dashboard", tabName = "dashboard", icon = icon("dashboard")),
+#        #menuItem("Widgets", icon = icon("th"), tabName = "widgets",
+#        #         badgeLabel = "new", badgeColor = "green")
+#                 menuItem("About", tabname="about", icon=icon("house")),
+#                 menuItem("Devices", tabname="devices", icon=icon("microscope")),
+#                 menuItem("Evaluation", tabname="evaluation", icon=icon("chart-simple")),
+#                 menuItem("Diagnostics", tabname="diagnostics", icon=icon("wrench"))
+#    )
+#)
+#
+#body <- dashboardBody(
+#    tabItems(
+#        tabItem(tabName = "dashboard",
+#                h2("Dashboard tab content")
+#        ),
+#        
+#        tabItem(tabName = "widgets",
+#                h2("Widgets tab content")
+#        )
+#    )
+#)
+#
+## Put them together into a dashboardPage
+#ui <- dashboardPage(
+#    dashboardHeader(title = "Simple tabs"),
+#    sidebar,
+#    body
+#)
 
 ui <- dashboardPage(
 
-    dashboardHeader(title="QUANT LCS Uncertainty"),
+    dashboardHeader(title="QUANT"),
     dashboardSidebar(
-            tags$style(".skin-blue .sidebar .shiny-download-link { color: #444; }"),
-            radioButtons("species",
-                         "Species",
-                         choices=c("CO", "NO", "NO2", "O3", "PM1", "PM10", "PM2.5"),
-                         selected="NO2"),
-            dateRangeInput("daterange",
-                           "Time period",
-                           startview="year",
-                           min="2019-12-10",
-                           max=today(),
-                           end=today(),
-                           start="2019-12-10"),
-            radioButtons("location",
-                         "Location",
-                         choices=c("Manchester", "London", "York"),
-                         selected="Manchester"),
-            sliderInput("avg",
-                         "Minute average",
-                         value=60,
-                         min=1,
-                         max=60),
-            checkboxInput("calibrate", "Recalibrate"),
-            checkboxGroupInput("devices",
-                               "Devices",
-                               choices=all_devices),
-            actionButton("plot_button",
-                         "Plot"),
-            downloadButton("download_button", "Download displayed data")
+            #tags$style(".skin-blue .sidebar .shiny-download-link { color: #444; }"),
+            sidebarMenu(
+                menuItem("About", tabName="about", icon=icon("house")),
+                menuItem("Devices", tabName="devices", icon=icon("microscope")),
+                menuItem("Evaluation", tabName="evaluation", icon=icon("chart-simple")),
+                menuItem("Diagnostics", tabName="diagnostics", icon=icon("wrench"))
+            )
+            #radioButtons("species",
+            #             "Species",
+            #             choices=c("CO", "NO", "NO2", "O3", "PM1", "PM10", "PM2.5"),
+            #             selected="NO2"),
+            #dateRangeInput("daterange",
+            #               "Time period",
+            #               startview="year",
+            #               min="2019-12-10",
+            #               max=today(),
+            #               end=today(),
+            #               start="2019-12-10"),
+            #radioButtons("location",
+            #             "Location",
+            #             choices=c("Manchester", "London", "York"),
+            #             selected="Manchester"),
+            #sliderInput("avg",
+            #             "Minute average",
+            #             value=60,
+            #             min=1,
+            #             max=60),
+            #checkboxInput("calibrate", "Recalibrate"),
+            #checkboxGroupInput("devices",
+            #                   "Devices",
+            #                   choices=all_devices),
+            #actionButton("plot_button",
+            #             "Plot"),
+            #downloadButton("download_button", "Download displayed data")
     ),
     dashboardBody(
-        fluidRow(
-            box(
-                title="Time series",
-                withSpinner(
-                    plotOutput("time_ref")
-                ), 
-                width=12
+        tabItems(
+            tabItem(tabName="about",
+                    h1("QUANT"),
+                    p("Some information about the study here")
             ),
-        ),
-        fluidRow(
-            box(
-                title="Scatter",
-                withSpinner(
-                    plotOutput("scatter")
-                ), 
-                width=12
+            tabItem(tabName="devices",
+                    h1("Particpating devices"),
+                    fluidRow(
+                        box(
+                            title="Device deployment history",
+                            withSpinner(
+                                plotOutput("deployment_plot")
+                            ),
+                            width=12
+                        ),
+                        box(
+                            title="Available sensors",
+                            withSpinner(
+                                htmlOutput("sensor_availability")
+                            ),
+                            width=12
+                        ),
+                        box(
+                            title="Calibration versions",
+                            withSpinner(
+                                plotOutput("cal_versions")
+                            ),
+                            width=12
+                        )
+                    )
             ),
-        ),
-        fluidRow(
-            column(
-                radioButtons("error_type",
-                             "Error type",
-                             choices=c("Absolute (ref - LCS)"="absolute", "REU (GDE)"="REU"),
-                             selected="absolute"),
-                width=3
+            tabItem(tabName="evaluation",
+                    h2("Evaluation"),
+                    p("Scatter/REU/BA")
             ),
-            column(
-                numericInput("min_reu",
-                             "Minimum REU to display",
-                             value=0),
-                width=3
-            ),
-            column(
-                numericInput("max_reu",
-                             "Maximum REU to display",
-                             value=200,
-                             min=100),
-                width=3
-            )
-        ),
-        fluidRow(
-            box(
-                title="Error vs time",
-                withSpinner(
-                    plotOutput("time_plot")
-                ),
-                width=12
-            )
-        ),
-        fluidRow(
-            box(
-                title="Error vs concentration",
-                withSpinner(
-                    plotOutput("conc_plot"),
-                ),
-                width=12
-            ),
-        ),
-        fluidRow(
-            box(
-                title="Device deployment history",
-                withSpinner(
-                    plotOutput("deployment_plot")
-                ),
-                width=12
+            tabItem(tabName="diagnostics",
+                    h2("Diagnostics"),
+                    p("Error vs time etc...")
             )
         )
+        #fluidRow(
+        #    box(
+        #        title="Time series",
+        #        withSpinner(
+        #            plotOutput("time_ref")
+        #        ), 
+        #        width=12
+        #    ),
+        #),
+        #fluidRow(
+        #    box(
+        #        title="Scatter",
+        #        withSpinner(
+        #            plotOutput("scatter")
+        #        ), 
+        #        width=12
+        #    ),
+        #),
+        #fluidRow(
+        #    column(
+        #        radioButtons("error_type",
+        #                     "Error type",
+        #                     choices=c("Absolute (ref - LCS)"="absolute", "REU (GDE)"="REU"),
+        #                     selected="absolute"),
+        #        width=3
+        #    ),
+        #    column(
+        #        numericInput("min_reu",
+        #                     "Minimum REU to display",
+        #                     value=0),
+        #        width=3
+        #    ),
+        #    column(
+        #        numericInput("max_reu",
+        #                     "Maximum REU to display",
+        #                     value=200,
+        #                     min=100),
+        #        width=3
+        #    )
+        #),
+        #fluidRow(
+        #    box(
+        #        title="Error vs time",
+        #        withSpinner(
+        #            plotOutput("time_plot")
+        #        ),
+        #        width=12
+        #    )
+        #),
+        #fluidRow(
+        #    box(
+        #        title="Error vs concentration",
+        #        withSpinner(
+        #            plotOutput("conc_plot"),
+        #        ),
+        #        width=12
+        #    ),
+        #),
     )
 )
 
 server <- function(input, output) {
     
-    con <- dbConnect(RSQLite::SQLite(), DB_FN)
-    lcs <- tbl(con, "lcs")
-    ref <- tbl(con, "reference")
-    deployments <- tbl(con, "deployments")
+    con <- dbConnect(odbc(), "QUANT")  # TODO update to use credentials file
+    instruments <- tbl(con, "lcsinstrument") |> 
+                    filter(study == "QUANT")
+    #lcs <- tbl(con, "lcs")
+    #ref <- tbl(con, "ref")
     
-    selected_data <- eventReactive(input$plot_button, {
-        start_time <- as.numeric(as_datetime(as_date(input$daterange[1])))
-        end_time <- as.numeric(as_datetime(as_date(input$daterange[2] + 1)))
-        avg_str <- sprintf("%d mins", input$avg)
-        
-        df <- lcs %>%
-            filter(variable == !!input$species,
-                   device %in% !!input$devices,
-                   timestamp >= start_time,
-                   timestamp < end_time) %>%
-            inner_join(deployments, by="device") %>%
-            filter(timestamp >= start, timestamp <= end) %>%
-            inner_join(ref, by=c("timestamp", "location", "variable")) %>%
-            collect() %>%
-            mutate(timestamp = floor_date(as_datetime(timestamp), avg_str)) %>%
-            group_by(timestamp, device) %>%
-            summarise(lcs = mean(lcs, na.rm=T),
-                      reference = mean(reference, na.rm=T)) %>%
-            ungroup()
-        
-        if (input$calibrate) {
-            df <- df %>%
-                      group_by(device) %>%
-                      mutate(lcs = predict(lm(formula=reference ~ lcs), newdata=cur_data())) %>%
-                      ungroup()
-        }
-        
-        df
-    })
-    
-    horizontal_line_height <- reactive({
-        if (input$error_type == "REU") {
-            25
-        } else if (input$error_type == "absolute") {
-            0
-        }
-    })
-    
-    error_data <- reactive({
-        if (input$error_type == "REU") {
-            err_func <- function(ref, lcs) {
-                vals <- reu_gde(x=ref, y=lcs, Approach="GDE")
-            }
-        } else if (input$error_type == "absolute") {
-            err_func <- function(ref, lcs) {
-                ref - lcs
-            }
-        }
-        selected_data() %>%
-            group_by(device) %>%
-            mutate(error = err_func(reference, lcs))
-    })
-
-    output$conc_plot <- renderPlot({
-        df <- error_data()
-        if (input$error_type == "REU") {
-            df <- df %>%
-                filter(error <= input$max_reu,
-                       error >= input$min_reu)
-        }
-        df %>%
-            ggplot(aes(x=reference, y=error)) +
-                geom_point(na.rm=T) +
-                geom_hline(yintercept = horizontal_line_height(), 
-                           colour="green",
-                           linetype="dashed") +
-                stat_smooth(method="gam", formula=y ~ s(x, bs="cs")) +
-                theme_bw() +
-                labs(x="Reference (ppb)", y=sprintf("%s", input$error_type)) +
-                facet_wrap(~device) 
-    })
-    
-    output$time_plot <- renderPlot({
-        if (input$error_type == "REU") {
-            summary_text <- error_data() %>%
-                group_by(device) %>%
-                summarise(lab = sprintf("Mean REU: %.2f%%", mean(error, na.rm=T)),
-                          x=min(timestamp) + 0.80 * (max(timestamp) - min(timestamp)), y=Inf)
-            
-        } else if (input$error_type == "absolute") {
-            summary_text <- error_data() %>%
-                group_by(device) %>%
-                summarise(lab = sprintf("RMSE: %.2f", sqrt(mean(error**2, na.rm=T))),
-                          x=min(timestamp) + 0.80 * (max(timestamp) - min(timestamp)), y=Inf)
-        }
-        
-        
-        df <- error_data()
-        if (input$error_type == "REU") {
-            df <- df %>%
-                filter(error <= input$max_reu,
-                       error >= input$min_reu)
-        }
-        
-        p <- df %>%
-            ggplot(aes(x=timestamp, y=error)) +
-                geom_line(na.rm=T) +
-                geom_hline(yintercept = horizontal_line_height(), 
-                           colour="green",
-                           linetype="dashed") +
-                geom_text(aes(label=lab, x=x, y=y), data=summary_text, vjust=1) +
-                theme_bw() +
-                labs(x="", y=sprintf("%s", input$error_type)) +
-                facet_wrap(~device)
-        
-        
-        p
-        
-    })
-    
-    output$time_ref <- renderPlot({
-        selected_data() %>%
-            ggplot(aes(x=timestamp)) +
-                geom_line(aes(y=lcs, colour="LCS"), na.rm=T) +
-                geom_line(aes(y=reference, colour="Reference"), na.rm=T) +
-                theme_bw() +
-                theme(legend.position="bottom") +
-                labs(x="", y=sprintf("%s", input$species)) +
-                facet_wrap(~device) +
-                scale_colour_manual("", values=c("Black", "Red"))
-    })
-    
-    output$scatter <- renderPlot({
-        selected_data() %>%
-            ggplot(aes(x=reference, y=lcs)) +
-                geom_point(na.rm=T) +
-                theme_bw() +
-                labs(x="Reference", y="LCS") +
-                geom_smooth(method="lm") +
-                stat_regline_equation(
-                    aes(label =  paste(..eq.label.., ..rr.label.., sep = "~~~~")),
-                ) + 
-                facet_wrap(~device) 
-    })
+    #selected_data <- eventReactive(input$plot_button, {
+    #    start_time <- as.numeric(as_datetime(as_date(input$daterange[1])))
+    #    end_time <- as.numeric(as_datetime(as_date(input$daterange[2] + 1)))
+    #    avg_str <- sprintf("%d mins", input$avg)
+    #    
+    #    df <- lcs %>%
+    #        filter(variable == !!input$species,
+    #               device %in% !!input$devices,
+    #               timestamp >= start_time,
+    #               timestamp < end_time) %>%
+    #        inner_join(deployments, by="device") %>%
+    #        filter(timestamp >= start, timestamp <= end) %>%
+    #        inner_join(ref, by=c("timestamp", "location", "variable")) %>%
+    #        collect() %>%
+    #        mutate(timestamp = floor_date(as_datetime(timestamp), avg_str)) %>%
+    #        group_by(timestamp, device) %>%
+    #        summarise(lcs = mean(lcs, na.rm=T),
+    #                  reference = mean(reference, na.rm=T)) %>%
+    #        ungroup()
+    #    
+    #    if (input$calibrate) {
+    #        df <- df %>%
+    #                  group_by(device) %>%
+    #                  mutate(lcs = predict(lm(formula=reference ~ lcs), newdata=cur_data())) %>%
+    #                  ungroup()
+    #    }
+    #    
+    #    df
+    #})
+    #
+    #horizontal_line_height <- reactive({
+    #    if (input$error_type == "REU") {
+    #        25
+    #    } else if (input$error_type == "absolute") {
+    #        0
+    #    }
+    #})
+    #
+    #error_data <- reactive({
+    #    if (input$error_type == "REU") {
+    #        err_func <- function(ref, lcs) {
+    #            vals <- reu_gde(x=ref, y=lcs, Approach="GDE")
+    #        }
+    #    } else if (input$error_type == "absolute") {
+    #        err_func <- function(ref, lcs) {
+    #            ref - lcs
+    #        }
+    #    }
+    #    selected_data() %>%
+    #        group_by(device) %>%
+    #        mutate(error = err_func(reference, lcs))
+    #})
+#
+    #output$conc_plot <- renderPlot({
+    #    df <- error_data()
+    #    if (input$error_type == "REU") {
+    #        df <- df %>%
+    #            filter(error <= input$max_reu,
+    #                   error >= input$min_reu)
+    #    }
+    #    df %>%
+    #        ggplot(aes(x=reference, y=error)) +
+    #            geom_point(na.rm=T) +
+    #            geom_hline(yintercept = horizontal_line_height(), 
+    #                       colour="green",
+    #                       linetype="dashed") +
+    #            stat_smooth(method="gam", formula=y ~ s(x, bs="cs")) +
+    #            theme_bw() +
+    #            labs(x="Reference (ppb)", y=sprintf("%s", input$error_type)) +
+    #            facet_wrap(~device) 
+    #})
+    #
+    #output$time_plot <- renderPlot({
+    #    if (input$error_type == "REU") {
+    #        summary_text <- error_data() %>%
+    #            group_by(device) %>%
+    #            summarise(lab = sprintf("Mean REU: %.2f%%", mean(error, na.rm=T)),
+    #                      x=min(timestamp) + 0.80 * (max(timestamp) - min(timestamp)), y=Inf)
+    #        
+    #    } else if (input$error_type == "absolute") {
+    #        summary_text <- error_data() %>%
+    #            group_by(device) %>%
+    #            summarise(lab = sprintf("RMSE: %.2f", sqrt(mean(error**2, na.rm=T))),
+    #                      x=min(timestamp) + 0.80 * (max(timestamp) - min(timestamp)), y=Inf)
+    #    }
+    #    
+    #    
+    #    df <- error_data()
+    #    if (input$error_type == "REU") {
+    #        df <- df %>%
+    #            filter(error <= input$max_reu,
+    #                   error >= input$min_reu)
+    #    }
+    #    
+    #    p <- df %>%
+    #        ggplot(aes(x=timestamp, y=error)) +
+    #            geom_line(na.rm=T) +
+    #            geom_hline(yintercept = horizontal_line_height(), 
+    #                       colour="green",
+    #                       linetype="dashed") +
+    #            geom_text(aes(label=lab, x=x, y=y), data=summary_text, vjust=1) +
+    #            theme_bw() +
+    #            labs(x="", y=sprintf("%s", input$error_type)) +
+    #            facet_wrap(~device)
+    #    
+    #    
+    #    p
+    #    
+    #})
+    #
+    #output$time_ref <- renderPlot({
+    #    selected_data() %>%
+    #        ggplot(aes(x=timestamp)) +
+    #            geom_line(aes(y=lcs, colour="LCS"), na.rm=T) +
+    #            geom_line(aes(y=reference, colour="Reference"), na.rm=T) +
+    #            theme_bw() +
+    #            theme(legend.position="bottom") +
+    #            labs(x="", y=sprintf("%s", input$species)) +
+    #            facet_wrap(~device) +
+    #            scale_colour_manual("", values=c("Black", "Red"))
+    #})
+    #
+    #output$scatter <- renderPlot({
+    #    selected_data() %>%
+    #        ggplot(aes(x=reference, y=lcs)) +
+    #            geom_point(na.rm=T) +
+    #            theme_bw() +
+    #            labs(x="Reference", y="LCS") +
+    #            geom_smooth(method="lm") +
+    #            stat_regline_equation(
+    #                aes(label =  paste(..eq.label.., ..rr.label.., sep = "~~~~")),
+    #            ) + 
+    #            facet_wrap(~device) 
+    #})
     
     
     output$deployment_plot <- renderPlot({
-        df <- deployments %>%
-            collect() %>%
-            mutate(start = as_datetime(start),
-                   end = as_datetime(end),
-                   range = as.integer(difftime(end, start, units="days")),
+        df <- tbl(con, "deployment") |>
+                        inner_join(instruments, by="instrument") |>
+            collect() |>
+            mutate(
+                   range = as.integer(difftime(finish, start, units="days")),
                    midpoint = as_date(start) + floor((range)/2),
-                   device=as.factor(device))
-        device_ids <- rev(levels(df$device))
+                   instrument=as.factor(instrument)
+            )
+        instrument_ids <- rev(levels(df$instrument))
         df %>%
-            ggplot(aes(x=midpoint, y=as.numeric(device), fill=location, width=range)) +
+            ggplot(aes(x=midpoint, y=as.numeric(instrument), fill=location, width=range)) +
                 geom_tile(na.rm=T) +
                 theme_bw() +
                 labs(x="", y="") +
@@ -308,25 +351,95 @@ server <- function(input, output) {
                 theme(panel.grid.major.x = element_blank(),
                       panel.grid.minor.x = element_blank(),
                       panel.grid.minor.y = element_blank()) +
-                scale_y_continuous(breaks = 1:length(device_ids),
-                                   labels = device_ids,
+                scale_y_continuous(breaks = 1:length(instrument_ids),
+                                   labels = instrument_ids,
                                    sec.axis = dup_axis()) +
                 scale_fill_discrete("") +
                 theme(legend.position="bottom")
     })
     
-    output$download_button <- downloadHandler(
-        filename = function() {
-            paste0("quant_extract_", Sys.Date(), ".csv")
-        },
-        content = function(file) {
-            df <- selected_data() %>%
-                    group_by(device) %>%
-                    mutate(reu = reu_gde(x=reference, y=lcs, Approach="GDE"),
-                           error = reference - lcs)
-            write_csv(df, file)
+    output$sensor_availability <- renderUI({
+        # Obtain which sensors are housed in which instruments
+        df <- tbl(con, "sensor") |>
+                inner_join(instruments, by="instrument") |>
+                filter(measurand %in% MEASURANDS) |>
+                select(instrument, measurand, sensornumber) |>
+                collect() 
+        # Add missing gaps
+        df <- expand_grid(instrument=unique(df$instrument), 
+                    measurand=MEASURANDS) |>
+            left_join(df, by=c("instrument", "measurand")) |>
+            mutate(sensornumber = ifelse(is.na(sensornumber), 0, sensornumber)) |>
+            pivot_wider(names_from=measurand,
+                        values_from=sensornumber,
+                        values_fn=sum) |>
+            rename(Instrument = instrument) |>
+            mutate(across(-Instrument,
+                   function(x) ifelse(x == 0, 'X', 
+                                      ifelse(x == 1, '✓', x))))
+            
+        tab <- df |>
+            kable(align=c("l", rep("c", length(MEASURANDS)))) |>
+            kable_styling(c("striped", "hover")) 
+        for (i in 2:ncol(df)) {
+            tab <- tab |> 
+                column_spec(i,
+                            background = ifelse(df[[i]] == 'X',
+                                                'salmon',
+                                                ifelse(df[[i]] == '✓', 'white', 'lightgreen')))
         }
-    )
+        HTML(tab)
+    })
+    
+    output$cal_versions <- renderPlot({
+        df <- tbl(con, "sensorcalibration") |>
+            inner_join(instruments, by="instrument") |>
+            filter(calibrationname != 'Rescraped',
+                   measurand %in% MEASURANDS) |>
+            group_by(company, measurand, calibrationname) |>
+            summarise(dateapplied = min(as_date(dateapplied), na.rm=T)) |>
+            collect() |>
+            ungroup() |>
+            arrange(company, dateapplied)
+        
+        df <- df |>
+            # It's possible to have simultaneous cals
+            group_by(company, measurand, dateapplied) |>
+            summarise(calibrationname = paste(calibrationname, collapse=' + ')) |>
+            ungroup() |>
+            group_by(company, measurand) |>
+            mutate(duration = as.numeric(difftime(lead(dateapplied, 1), dateapplied, units="days")),
+                   duration = ifelse(is.na(duration),
+                                     as.numeric(difftime(STUDY_END, dateapplied, units="days")),
+                                     duration),
+                   midpoint = dateapplied + (duration / 2)) |>
+            ungroup()
+        
+        df |>
+            ggplot(aes(y=measurand)) +
+                geom_tile(aes(x=dateapplied),
+                          linewidth=2) +
+                geom_text(aes(x=midpoint, label=calibrationname),
+                          size=3) +
+                facet_wrap(~company, ncol=1,
+                           scales="free_y") +
+                xlim(c(STUDY_START-10, STUDY_END)) +
+                labs(x="", y="") +
+                theme_bw()
+    })
+    
+    #output$download_button <- downloadHandler(
+    #    filename = function() {
+    #        paste0("quant_extract_", Sys.Date(), ".csv")
+    #    },
+    #    content = function(file) {
+    #        df <- selected_data() %>%
+    #                group_by(device) %>%
+    #                mutate(reu = reu_gde(x=reference, y=lcs, Approach="GDE"),
+    #                       error = reference - lcs)
+    #        write_csv(df, file)
+    #    }
+    #)
     
 }
 

--- a/server.R
+++ b/server.R
@@ -310,13 +310,30 @@ server <- function(session, input, output) {
         create_update_selection_listeners(n_comparisons)
         
         if (n_comparisons == MAX_COMPARISONS) disable("add_comparison")
-        if (n_comparisons == 2) enable("remove_comparison")
+        if (n_comparisons == 2) {
+            enable("remove_comparison")
+            enable("remove_all_comparison")
+        }
     })
     
     observeEvent(input$remove_comparison, {
         removeUI(sprintf("#row_%d", n_comparisons))
         n_comparisons <<- n_comparisons - 1
-        if (n_comparisons == 1) disable("remove_comparison")
+        if (n_comparisons == 1) {
+            enable("add_comparison")
+            disable("remove_comparison")
+            disable("remove_all_comparison")
+        }
+    })
+    
+    observeEvent(input$remove_all_comparison, {
+        for (i in 2:n_comparisons) {
+            removeUI(sprintf("#row_%d", i))
+        }
+        n_comparisons <<- 1
+        disable("remove_comparison")
+        disable("remove_all_comparison")
+        enable("add_comparison")
     })
     ########################### End listeners to add/remove instrument boxes
     

--- a/server.R
+++ b/server.R
@@ -1,51 +1,26 @@
 library(DBI)
-library(odbc)
 library(knitr)
 library(kableExtra)
-library(RSQLite)
+library(RPostgres)
 library(shiny)
 library(tidyverse)
 library(lubridate)
 library(ggpubr)
+library(jsonlite)
 
 MEASURANDS <- c("NO2", "O3", "PM2.5")
 STUDY_START <- as_date("2019-12-10")
 STUDY_END <- as_date("2022-10-31")
-
-#sidebar <- dashboardSidebar(
-#    sidebarMenu(
-#        #menuItem("Dashboard", tabName = "dashboard", icon = icon("dashboard")),
-#        #menuItem("Widgets", icon = icon("th"), tabName = "widgets",
-#        #         badgeLabel = "new", badgeColor = "green")
-#                 menuItem("About", tabname="about", icon=icon("house")),
-#                 menuItem("Devices", tabname="devices", icon=icon("microscope")),
-#                 menuItem("Evaluation", tabname="evaluation", icon=icon("chart-simple")),
-#                 menuItem("Diagnostics", tabname="diagnostics", icon=icon("wrench"))
-#    )
-#)
-#
-#body <- dashboardBody(
-#    tabItems(
-#        tabItem(tabName = "dashboard",
-#                h2("Dashboard tab content")
-#        ),
-#        
-#        tabItem(tabName = "widgets",
-#                h2("Widgets tab content")
-#        )
-#    )
-#)
-#
-## Put them together into a dashboardPage
-#ui <- dashboardPage(
-#    dashboardHeader(title = "Simple tabs"),
-#    sidebar,
-#    body
-#)
+CREDS <- fromJSON("creds.json")
 
 server <- function(input, output) {
     
-    con <- dbConnect(odbc(), "QUANT")  # TODO update to use credentials file
+    con <- dbConnect(Postgres(),
+                     dbname=CREDS$db,
+                     host=CREDS$host,
+                     port=CREDS$port,
+                     user=CREDS$username,
+                     password=CREDS$password)
     instruments <- tbl(con, "lcsinstrument") |> 
                     filter(study == "QUANT")
     #lcs <- tbl(con, "lcs")

--- a/server.R
+++ b/server.R
@@ -9,8 +9,6 @@ library(lubridate)
 library(jsonlite)
 library(quantr)
 
-# TODO when click remove, also remove datasets and reset options
-
 options(dplyr.summarise.inform=FALSE)
 
 MEASURANDS <- c("NO2", "O3", "PM2.5")
@@ -61,7 +59,6 @@ server <- function(session, input, output) {
     create_evaluation_row <- function(i) {
         div(
             fluidRow(
-            # TODO Make same height
             box(
                 title="Controls",
                 selectInput(sprintf("instrument_select_%d", i),
@@ -78,10 +75,13 @@ server <- function(session, input, output) {
                                     choices=c("out-of-box")),
                 selectInput(sprintf("sensornumber_%d", i),
                             "Sensor number", choices=c(1)),
+                br(),
+                br(),
                 actionButton(sprintf("plot_%d", i),
                              "Plot"),
                 hidden(downloadButton(sprintf("download_%d", i),
                              "Download data")),
+                height=462.5,
                 width=3,
                 solidHeader = TRUE,
                 status="success"
@@ -417,8 +417,13 @@ server <- function(session, input, output) {
         }
     })
     
+    remove_row <- function(i) {
+        removeUI(sprintf("#row_%d", i))
+        dfs[[sprintf("df_%d", i)]] <- NULL
+    }
+
     observeEvent(input$remove_comparison, {
-        removeUI(sprintf("#row_%d", n_comparisons))
+        remove_row(n_comparisons)
         n_comparisons <<- n_comparisons - 1
         if (n_comparisons == 1) {
             enable("add_comparison")
@@ -430,7 +435,7 @@ server <- function(session, input, output) {
     
     observeEvent(input$remove_all_comparison, {
         for (i in 2:n_comparisons) {
-            removeUI(sprintf("#row_%d", i))
+            remove_row(i)
         }
         n_comparisons <<- 1
         disable("remove_comparison")

--- a/server.R
+++ b/server.R
@@ -3,15 +3,40 @@ library(knitr)
 library(kableExtra)
 library(RPostgres)
 library(shiny)
+library(shinyjs)
 library(tidyverse)
 library(lubridate)
 library(ggpubr)
 library(jsonlite)
+library(quantr)
 
 MEASURANDS <- c("NO2", "O3", "PM2.5")
 STUDY_START <- as_date("2019-12-10")
 STUDY_END <- as_date("2022-10-31")
 CREDS <- fromJSON("creds.json")
+MAX_COMPARISONS <- 4
+
+download_data <- function(con, in_instrument, in_pollutant, in_start, in_end, in_sensornumber, in_cal) {
+    # TODO Add option for minutely
+    lcs <- tbl(con, "lcs_hourly") |>
+        filter(instrument == in_instrument,
+               measurand == in_pollutant,
+               between(time, in_start, in_end),
+               sensornumber == in_sensornumber,
+               version == in_cal,
+               is.na(flag) | flag != 'Error') |>
+        rename(lcs=measurement)
+    # Obtain corresponding reference
+    lcs <- lcs |>
+            inner_join(tbl(con, "ref_hourly") |> select(-version) |> rename(ref=measurement), 
+                       by=c("location", "time", "measurand")) |>
+            collect()
+    lcs
+}
+
+
+
+########################################
 
 server <- function(input, output) {
     
@@ -23,145 +48,112 @@ server <- function(input, output) {
                      password=CREDS$password)
     instruments <- tbl(con, "lcsinstrument") |> 
                     filter(study == "QUANT")
-    #lcs <- tbl(con, "lcs")
-    #ref <- tbl(con, "ref")
-    
-    #selected_data <- eventReactive(input$plot_button, {
-    #    start_time <- as.numeric(as_datetime(as_date(input$daterange[1])))
-    #    end_time <- as.numeric(as_datetime(as_date(input$daterange[2] + 1)))
-    #    avg_str <- sprintf("%d mins", input$avg)
-    #    
-    #    df <- lcs %>%
-    #        filter(variable == !!input$species,
-    #               device %in% !!input$devices,
-    #               timestamp >= start_time,
-    #               timestamp < end_time) %>%
-    #        inner_join(deployments, by="device") %>%
-    #        filter(timestamp >= start, timestamp <= end) %>%
-    #        inner_join(ref, by=c("timestamp", "location", "variable")) %>%
-    #        collect() %>%
-    #        mutate(timestamp = floor_date(as_datetime(timestamp), avg_str)) %>%
-    #        group_by(timestamp, device) %>%
-    #        summarise(lcs = mean(lcs, na.rm=T),
-    #                  reference = mean(reference, na.rm=T)) %>%
-    #        ungroup()
-    #    
-    #    if (input$calibrate) {
-    #        df <- df %>%
-    #                  group_by(device) %>%
-    #                  mutate(lcs = predict(lm(formula=reference ~ lcs), newdata=cur_data())) %>%
-    #                  ungroup()
-    #    }
-    #    
-    #    df
-    #})
-    #
-    #horizontal_line_height <- reactive({
-    #    if (input$error_type == "REU") {
-    #        25
-    #    } else if (input$error_type == "absolute") {
-    #        0
-    #    }
-    #})
-    #
-    #error_data <- reactive({
-    #    if (input$error_type == "REU") {
-    #        err_func <- function(ref, lcs) {
-    #            vals <- reu_gde(x=ref, y=lcs, Approach="GDE")
-    #        }
-    #    } else if (input$error_type == "absolute") {
-    #        err_func <- function(ref, lcs) {
-    #            ref - lcs
-    #        }
-    #    }
-    #    selected_data() %>%
-    #        group_by(device) %>%
-    #        mutate(error = err_func(reference, lcs))
-    #})
-#
-    #output$conc_plot <- renderPlot({
-    #    df <- error_data()
-    #    if (input$error_type == "REU") {
-    #        df <- df %>%
-    #            filter(error <= input$max_reu,
-    #                   error >= input$min_reu)
-    #    }
-    #    df %>%
-    #        ggplot(aes(x=reference, y=error)) +
-    #            geom_point(na.rm=T) +
-    #            geom_hline(yintercept = horizontal_line_height(), 
-    #                       colour="green",
-    #                       linetype="dashed") +
-    #            stat_smooth(method="gam", formula=y ~ s(x, bs="cs")) +
-    #            theme_bw() +
-    #            labs(x="Reference (ppb)", y=sprintf("%s", input$error_type)) +
-    #            facet_wrap(~device) 
-    #})
-    #
-    #output$time_plot <- renderPlot({
-    #    if (input$error_type == "REU") {
-    #        summary_text <- error_data() %>%
-    #            group_by(device) %>%
-    #            summarise(lab = sprintf("Mean REU: %.2f%%", mean(error, na.rm=T)),
-    #                      x=min(timestamp) + 0.80 * (max(timestamp) - min(timestamp)), y=Inf)
-    #        
-    #    } else if (input$error_type == "absolute") {
-    #        summary_text <- error_data() %>%
-    #            group_by(device) %>%
-    #            summarise(lab = sprintf("RMSE: %.2f", sqrt(mean(error**2, na.rm=T))),
-    #                      x=min(timestamp) + 0.80 * (max(timestamp) - min(timestamp)), y=Inf)
-    #    }
-    #    
-    #    
-    #    df <- error_data()
-    #    if (input$error_type == "REU") {
-    #        df <- df %>%
-    #            filter(error <= input$max_reu,
-    #                   error >= input$min_reu)
-    #    }
-    #    
-    #    p <- df %>%
-    #        ggplot(aes(x=timestamp, y=error)) +
-    #            geom_line(na.rm=T) +
-    #            geom_hline(yintercept = horizontal_line_height(), 
-    #                       colour="green",
-    #                       linetype="dashed") +
-    #            geom_text(aes(label=lab, x=x, y=y), data=summary_text, vjust=1) +
-    #            theme_bw() +
-    #            labs(x="", y=sprintf("%s", input$error_type)) +
-    #            facet_wrap(~device)
-    #    
-    #    
-    #    p
-    #    
-    #})
-    #
-    #output$time_ref <- renderPlot({
-    #    selected_data() %>%
-    #        ggplot(aes(x=timestamp)) +
-    #            geom_line(aes(y=lcs, colour="LCS"), na.rm=T) +
-    #            geom_line(aes(y=reference, colour="Reference"), na.rm=T) +
-    #            theme_bw() +
-    #            theme(legend.position="bottom") +
-    #            labs(x="", y=sprintf("%s", input$species)) +
-    #            facet_wrap(~device) +
-    #            scale_colour_manual("", values=c("Black", "Red"))
-    #})
-    #
-    #output$scatter <- renderPlot({
-    #    selected_data() %>%
-    #        ggplot(aes(x=reference, y=lcs)) +
-    #            geom_point(na.rm=T) +
-    #            theme_bw() +
-    #            labs(x="Reference", y="LCS") +
-    #            geom_smooth(method="lm") +
-    #            stat_regline_equation(
-    #                aes(label =  paste(..eq.label.., ..rr.label.., sep = "~~~~")),
-    #            ) + 
-    #            facet_wrap(~device) 
-    #})
+    instrument_names <- instruments |> select(instrument) |> collect() |> pull(instrument)
+    n_comparisons <- 1
+    dfs <- reactiveValues()
     
     
+    ################################ Functions to dynamically create UI
+    create_evaluation_row <- function(i) {
+        div(
+            fluidRow(
+            box(
+                title="Controls",
+                # TODO Add time range, calibration, sensor number
+                selectInput(sprintf("instrument_select_%d", i), 
+                            "Select instrument",
+                            choices=instrument_names),
+                actionButton(sprintf("plot_%d", i),
+                             "Plot"),
+                # TODO add option to download data
+                width=3,
+                solidHeader = TRUE,
+                status="success"
+            ),
+            box(
+                title="Time-series",
+                withSpinner(plotOutput(sprintf("timeseries_%d", i))),
+                width=3,
+                solidHeader = TRUE,
+                status="primary"
+            ),
+            box(
+                title="Scatter",
+                withSpinner(plotOutput(sprintf("scatter_%d", i))),
+                width=3,
+                solidHeader = TRUE,
+                status="primary"
+            ),
+            box(
+                title="Bland-Altman",
+                withSpinner(plotOutput(sprintf("ba_%d", i))),
+                width=3,
+                solidHeader = TRUE,
+                status="primary"
+            )
+        ), id=sprintf("row_%d", i)
+        )
+    }
+
+    create_plot_listener <- function(i) {
+        observeEvent(input[[sprintf("plot_%d", i)]], {
+            dfs[[sprintf("df_%d", i)]] <- download_data(
+                con,
+                input[[sprintf("instrument_select_%d", i)]],
+                # TODO have these values be user selectable
+                input$measurand,
+                "2022-01-01",
+                "2022-01-31",
+                "1",
+                "cal2"
+            )
+        }, ignoreInit = TRUE)
+    }
+    
+    create_evaluation_plot_renders <- function(i) {
+        df_id <- sprintf("df_%d", i)
+        
+        # Time-series
+        output[[sprintf("timeseries_%d", i)]] <- renderPlot({
+            df <- dfs[[df_id]]
+            req(df)
+            shiny::validate(
+                need(nrow(df) > 0,
+                     "No datapoints found, check selection criteria."
+                 )
+            )
+            plot_time_series(df, lcs_column="lcs", reference_column="ref", time_column="time") +
+                guides(colour="legend") +
+                theme(legend.position = c(0.9, 0.9),
+                      legend.background = element_rect(fill=NA))
+        })
+        
+        # Scatter
+        output[[sprintf("scatter_%d", i)]] <- renderPlot({
+            df <- dfs[[df_id]]
+            req(df)
+            shiny::validate(
+                need(nrow(df) > 0,
+                     "No datapoints found, check selection criteria."
+                 )
+            )
+            plot_scatter(df, lcs_column="lcs", reference_column="ref") + coord_cartesian()
+        })
+        
+        # Bland-Altman
+        output[[sprintf("ba_%d", i)]] <- renderPlot({
+            df <- dfs[[df_id]]
+            req(df)
+            shiny::validate(
+                need(nrow(df) > 0,
+                     "No datapoints found, check selection criteria."
+                 )
+            )
+            plot_bland_altman(df, lcs_column="lcs", reference_column="ref")
+        })
+    }
+    ############################ End functions to dynamically create plots
+
     output$deployment_plot <- renderPlot({
         df <- tbl(con, "deployment") |>
                         inner_join(instruments, by="instrument") |>
@@ -259,17 +251,40 @@ server <- function(input, output) {
                 theme_bw()
     })
     
-    #output$download_button <- downloadHandler(
-    #    filename = function() {
-    #        paste0("quant_extract_", Sys.Date(), ".csv")
-    #    },
-    #    content = function(file) {
-    #        df <- selected_data() %>%
-    #                group_by(device) %>%
-    #                mutate(reu = reu_gde(x=reference, y=lcs, Approach="GDE"),
-    #                       error = reference - lcs)
-    #        write_csv(df, file)
-    #    }
-    #)
     
+    # By default have the UI, output render functions, listener for 1 sensor
+    output$evaluation_content <- renderUI({
+        create_evaluation_row(1)
+    })
+    create_plot_listener(1)
+    create_evaluation_plot_renders(1)
+    
+    ########################### Listeners to add/remove instrument boxes
+    observeEvent(input$add_comparison, {
+        n_comparisons <<- n_comparisons + 1
+        # Insert UI and create plot renderers and button listeners
+        new_row <- create_evaluation_row(n_comparisons)
+        insertUI("#evaluation_content",
+                 "beforeEnd",
+                 new_row,
+                 immediate=FALSE
+                 )
+        create_plot_listener(n_comparisons)
+        create_evaluation_plot_renders(n_comparisons)
+        
+        if (n_comparisons == MAX_COMPARISONS) disable("add_comparison")
+        if (n_comparisons == 2) enable("remove_comparison")
+    })
+    
+    observeEvent(input$remove_comparison, {
+        removeUI(sprintf("#row_%d", n_comparisons))
+        n_comparisons <<- n_comparisons - 1
+        if (n_comparisons == 1) disable("remove_comparison")
+    })
+    ########################### End listeners to add/remove instrument boxes
+    
+    output$measurand_selection <- renderUI({
+        selectInput("measurand", "Pollutant",
+                    choices=MEASURANDS)
+    })
 }

--- a/server.R
+++ b/server.R
@@ -9,6 +9,8 @@ library(lubridate)
 library(jsonlite)
 library(quantr)
 
+options(dplyr.summarise.inform=FALSE)
+
 MEASURANDS <- c("NO2", "O3", "PM2.5")
 STUDY_START <- as_date("2019-12-10")
 STUDY_END <- as_date("2022-10-31")
@@ -149,7 +151,7 @@ server <- function(session, input, output) {
                      "No datapoints found, check selection criteria."
                  )
             )
-            plot_scatter(df, lcs_column="lcs", reference_column="ref") + coord_cartesian()
+            suppressMessages(plot_scatter(df, lcs_column="lcs", reference_column="ref") + coord_cartesian())
         })
         
         # Bland-Altman

--- a/server.R
+++ b/server.R
@@ -6,10 +6,7 @@ library(RSQLite)
 library(shiny)
 library(tidyverse)
 library(lubridate)
-library(shinydashboard)
-library(shinycssloaders)
 library(ggpubr)
-#source("reu.R")
 
 MEASURANDS <- c("NO2", "O3", "PM2.5")
 STUDY_START <- as_date("2019-12-10")
@@ -45,147 +42,6 @@ STUDY_END <- as_date("2022-10-31")
 #    sidebar,
 #    body
 #)
-
-ui <- dashboardPage(
-
-    dashboardHeader(title="QUANT"),
-    dashboardSidebar(
-            #tags$style(".skin-blue .sidebar .shiny-download-link { color: #444; }"),
-            sidebarMenu(
-                menuItem("About", tabName="about", icon=icon("house")),
-                menuItem("Devices", tabName="devices", icon=icon("microscope")),
-                menuItem("Evaluation", tabName="evaluation", icon=icon("chart-simple")),
-                menuItem("Diagnostics", tabName="diagnostics", icon=icon("wrench"))
-            )
-            #radioButtons("species",
-            #             "Species",
-            #             choices=c("CO", "NO", "NO2", "O3", "PM1", "PM10", "PM2.5"),
-            #             selected="NO2"),
-            #dateRangeInput("daterange",
-            #               "Time period",
-            #               startview="year",
-            #               min="2019-12-10",
-            #               max=today(),
-            #               end=today(),
-            #               start="2019-12-10"),
-            #radioButtons("location",
-            #             "Location",
-            #             choices=c("Manchester", "London", "York"),
-            #             selected="Manchester"),
-            #sliderInput("avg",
-            #             "Minute average",
-            #             value=60,
-            #             min=1,
-            #             max=60),
-            #checkboxInput("calibrate", "Recalibrate"),
-            #checkboxGroupInput("devices",
-            #                   "Devices",
-            #                   choices=all_devices),
-            #actionButton("plot_button",
-            #             "Plot"),
-            #downloadButton("download_button", "Download displayed data")
-    ),
-    dashboardBody(
-        tabItems(
-            tabItem(tabName="about",
-                    h1("QUANT"),
-                    p("Some information about the study here")
-            ),
-            tabItem(tabName="devices",
-                    h1("Particpating devices"),
-                    fluidRow(
-                        box(
-                            title="Device deployment history",
-                            withSpinner(
-                                plotOutput("deployment_plot")
-                            ),
-                            width=12
-                        ),
-                        box(
-                            title="Available sensors",
-                            withSpinner(
-                                htmlOutput("sensor_availability")
-                            ),
-                            width=12
-                        ),
-                        box(
-                            title="Calibration versions",
-                            withSpinner(
-                                plotOutput("cal_versions")
-                            ),
-                            width=12
-                        )
-                    )
-            ),
-            tabItem(tabName="evaluation",
-                    h2("Evaluation"),
-                    p("Scatter/REU/BA")
-            ),
-            tabItem(tabName="diagnostics",
-                    h2("Diagnostics"),
-                    p("Error vs time etc...")
-            )
-        )
-        #fluidRow(
-        #    box(
-        #        title="Time series",
-        #        withSpinner(
-        #            plotOutput("time_ref")
-        #        ), 
-        #        width=12
-        #    ),
-        #),
-        #fluidRow(
-        #    box(
-        #        title="Scatter",
-        #        withSpinner(
-        #            plotOutput("scatter")
-        #        ), 
-        #        width=12
-        #    ),
-        #),
-        #fluidRow(
-        #    column(
-        #        radioButtons("error_type",
-        #                     "Error type",
-        #                     choices=c("Absolute (ref - LCS)"="absolute", "REU (GDE)"="REU"),
-        #                     selected="absolute"),
-        #        width=3
-        #    ),
-        #    column(
-        #        numericInput("min_reu",
-        #                     "Minimum REU to display",
-        #                     value=0),
-        #        width=3
-        #    ),
-        #    column(
-        #        numericInput("max_reu",
-        #                     "Maximum REU to display",
-        #                     value=200,
-        #                     min=100),
-        #        width=3
-        #    )
-        #),
-        #fluidRow(
-        #    box(
-        #        title="Error vs time",
-        #        withSpinner(
-        #            plotOutput("time_plot")
-        #        ),
-        #        width=12
-        #    )
-        #),
-        #fluidRow(
-        #    box(
-        #        title="Error vs concentration",
-        #        withSpinner(
-        #            plotOutput("conc_plot"),
-        #        ),
-        #        width=12
-        #    ),
-        #),
-    )
-)
 
 server <- function(input, output) {
     
@@ -442,5 +298,3 @@ server <- function(input, output) {
     #)
     
 }
-
-shinyApp(ui = ui, server = server)

--- a/ui.R
+++ b/ui.R
@@ -83,12 +83,20 @@ ui <- dashboardPage(
                         actionButton("copy_comparison", "Copy last device"),
                         disabled(actionButton("remove_comparison", "Remove device")),
                         disabled(actionButton("remove_all_comparison", "Remove all devices")),
+                        # TODO Add minutely
+                        radioButtons("timeavg", "Time resolution", 
+                                     choices=c("Hourly", "Daily"),
+                                     selected="Hourly",
+                                     inline=TRUE),
                         uiOutput("measurand_selection")
                     ),
                     br(),
                     uiOutput("evaluation_content")
             ),
             tabItem(tabName="diagnostics",
+                    # TODO
+                    # Error vs reference,
+                    # Error vs time
                     h2("Diagnostics"),
             )
         )

--- a/ui.R
+++ b/ui.R
@@ -80,6 +80,7 @@ ui <- dashboardPage(
                     fluidRow(
                         # TODO clean up into a single row
                         actionButton("add_comparison", "Add device"),
+                        actionButton("copy_comparison", "Copy last device"),
                         disabled(actionButton("remove_comparison", "Remove device")),
                         disabled(actionButton("remove_all_comparison", "Remove all devices")),
                         uiOutput("measurand_selection")

--- a/ui.R
+++ b/ui.R
@@ -1,4 +1,5 @@
 library(shiny)
+library(shinyjs)
 library(shinydashboard)
 library(shinycssloaders)
 
@@ -42,6 +43,7 @@ ui <- dashboardPage(
             #downloadButton("download_button", "Download displayed data")
     ),
     dashboardBody(
+        useShinyjs(),
         tabItems(
             tabItem(tabName="about",
                     h1("QUANT"),
@@ -74,12 +76,18 @@ ui <- dashboardPage(
                     )
             ),
             tabItem(tabName="evaluation",
-                    h2("Evaluation"),
-                    p("Scatter/REU/BA")
+                    h2("Compare devices"),
+                    fluidRow(
+                        # TODO clean up into a single row
+                        actionButton("add_comparison", "Add device"),
+                        disabled(actionButton("remove_comparison", "Remove device")),
+                        uiOutput("measurand_selection")
+                    ),
+                    br(),
+                    uiOutput("evaluation_content")
             ),
             tabItem(tabName="diagnostics",
                     h2("Diagnostics"),
-                    p("Error vs time etc...")
             )
         )
         #fluidRow(

--- a/ui.R
+++ b/ui.R
@@ -1,0 +1,144 @@
+library(shiny)
+library(shinydashboard)
+library(shinycssloaders)
+
+ui <- dashboardPage(
+
+    dashboardHeader(title="QUANT"),
+    dashboardSidebar(
+            #tags$style(".skin-blue .sidebar .shiny-download-link { color: #444; }"),
+            sidebarMenu(
+                menuItem("About", tabName="about", icon=icon("house")),
+                menuItem("Devices", tabName="devices", icon=icon("microscope")),
+                menuItem("Evaluation", tabName="evaluation", icon=icon("chart-simple")),
+                menuItem("Diagnostics", tabName="diagnostics", icon=icon("wrench"))
+            )
+            #radioButtons("species",
+            #             "Species",
+            #             choices=c("CO", "NO", "NO2", "O3", "PM1", "PM10", "PM2.5"),
+            #             selected="NO2"),
+            #dateRangeInput("daterange",
+            #               "Time period",
+            #               startview="year",
+            #               min="2019-12-10",
+            #               max=today(),
+            #               end=today(),
+            #               start="2019-12-10"),
+            #radioButtons("location",
+            #             "Location",
+            #             choices=c("Manchester", "London", "York"),
+            #             selected="Manchester"),
+            #sliderInput("avg",
+            #             "Minute average",
+            #             value=60,
+            #             min=1,
+            #             max=60),
+            #checkboxInput("calibrate", "Recalibrate"),
+            #checkboxGroupInput("devices",
+            #                   "Devices",
+            #                   choices=all_devices),
+            #actionButton("plot_button",
+            #             "Plot"),
+            #downloadButton("download_button", "Download displayed data")
+    ),
+    dashboardBody(
+        tabItems(
+            tabItem(tabName="about",
+                    h1("QUANT"),
+                    p("Some information about the study here")
+            ),
+            tabItem(tabName="devices",
+                    h1("Particpating devices"),
+                    fluidRow(
+                        box(
+                            title="Device deployment history",
+                            withSpinner(
+                                plotOutput("deployment_plot")
+                            ),
+                            width=12
+                        ),
+                        box(
+                            title="Available sensors",
+                            withSpinner(
+                                htmlOutput("sensor_availability")
+                            ),
+                            width=12
+                        ),
+                        box(
+                            title="Calibration versions",
+                            withSpinner(
+                                plotOutput("cal_versions")
+                            ),
+                            width=12
+                        )
+                    )
+            ),
+            tabItem(tabName="evaluation",
+                    h2("Evaluation"),
+                    p("Scatter/REU/BA")
+            ),
+            tabItem(tabName="diagnostics",
+                    h2("Diagnostics"),
+                    p("Error vs time etc...")
+            )
+        )
+        #fluidRow(
+        #    box(
+        #        title="Time series",
+        #        withSpinner(
+        #            plotOutput("time_ref")
+        #        ), 
+        #        width=12
+        #    ),
+        #),
+        #fluidRow(
+        #    box(
+        #        title="Scatter",
+        #        withSpinner(
+        #            plotOutput("scatter")
+        #        ), 
+        #        width=12
+        #    ),
+        #),
+        #fluidRow(
+        #    column(
+        #        radioButtons("error_type",
+        #                     "Error type",
+        #                     choices=c("Absolute (ref - LCS)"="absolute", "REU (GDE)"="REU"),
+        #                     selected="absolute"),
+        #        width=3
+        #    ),
+        #    column(
+        #        numericInput("min_reu",
+        #                     "Minimum REU to display",
+        #                     value=0),
+        #        width=3
+        #    ),
+        #    column(
+        #        numericInput("max_reu",
+        #                     "Maximum REU to display",
+        #                     value=200,
+        #                     min=100),
+        #        width=3
+        #    )
+        #),
+        #fluidRow(
+        #    box(
+        #        title="Error vs time",
+        #        withSpinner(
+        #            plotOutput("time_plot")
+        #        ),
+        #        width=12
+        #    )
+        #),
+        #fluidRow(
+        #    box(
+        #        title="Error vs concentration",
+        #        withSpinner(
+        #            plotOutput("conc_plot"),
+        #        ),
+        #        width=12
+        #    ),
+        #),
+    )
+)

--- a/ui.R
+++ b/ui.R
@@ -60,16 +60,16 @@ ui <- dashboardPage(
                             width=12
                         ),
                         box(
-                            title="Available sensors",
+                            title="Calibration versions",
                             withSpinner(
-                                htmlOutput("sensor_availability")
+                                plotOutput("cal_versions")
                             ),
                             width=12
                         ),
                         box(
-                            title="Calibration versions",
+                            title="Available sensors",
                             withSpinner(
-                                plotOutput("cal_versions")
+                                htmlOutput("sensor_availability")
                             ),
                             width=12
                         )

--- a/ui.R
+++ b/ui.R
@@ -81,6 +81,7 @@ ui <- dashboardPage(
                         # TODO clean up into a single row
                         actionButton("add_comparison", "Add device"),
                         disabled(actionButton("remove_comparison", "Remove device")),
+                        disabled(actionButton("remove_all_comparison", "Remove all devices")),
                         uiOutput("measurand_selection")
                     ),
                     br(),


### PR DESCRIPTION
Initial release of a working version with core functionality, including:

  - Plot up to 4 devices simultaneously with time-series, bland-altmann, and a regression plot
  - Compare NO2, O3, and PM2.5
  - Plots showing the deployment history of each device as well as the sensors contained in each unit
  - Only main study devices are included for now
  - Allows user to specify specific sensor number and calibration version for each device
  - Can choose between hourly or daily time resolution
  - Users can download the plotted dataset

Outstanding features:

  - Add diagnostics area showing plots of errors against predicted, time, met conditions etc...
  - Allow for minutely data
  - Clean up UI (notably the plot selection controls)
  - Add WPS
  - Show location of device when plotting